### PR TITLE
exclude managed/proxy/abstract models for adding db-comments

### DIFF
--- a/django_db_comments/db_comments.py
+++ b/django_db_comments/db_comments.py
@@ -101,7 +101,7 @@ def copy_help_texts_to_database(
     table_comments = {
         model._meta.db_table: model._meta.verbose_name.title()
         for model in app_config.get_models()
-        if model._meta.verbose_name
+        if model._meta.verbose_name and model._meta.managed and not model._meta.proxy and not model._meta.abstract
     }
 
     if table_comments:

--- a/django_db_comments/db_comments.py
+++ b/django_db_comments/db_comments.py
@@ -92,7 +92,7 @@ def copy_help_texts_to_database(
     app_models = app_config.get_models()
 
     columns_comments = {
-        model._meta.db_table: get_comments_for_model(model) for model in app_models
+        model._meta.db_table: get_comments_for_model(model) for model in app_models if model._meta.managed and not model._meta.proxy and not model._meta.abstract
     }
 
     if columns_comments:


### PR DESCRIPTION
https://github.com/vanadium23/django-db-comments/issues/11
Trying excluding these models since they don't have their own database tables