### PR TITLE
Fix automatic AppConfig detection warning in Django 3.2+

### DIFF
--- a/django_db_comments/__init__.py
+++ b/django_db_comments/__init__.py
@@ -1,3 +1,6 @@
+import django
+
 __version__ = "0.4.1"
 
-default_app_config = "django_db_comments.apps.DjangoDbCommentsConfig"
+if django.VERSION < (3, 2):
+    default_app_config = "django_db_comments.apps.DjangoDbCommentsConfig"


### PR DESCRIPTION
Django 3.2 [added](https://docs.djangoproject.com/en/4.1/releases/3.2/#automatic-appconfig-discovery) automatic AppConfig discovery and deprecated setting `default_app_config`.

This gives the following warning on newer Django versions:
`RemovedInDjango41Warning: 'django_db_comments' defines default_app_config = 'django_db_comments.apps.DjangoDbCommentsConfig'. Django now detects this configuration automatically. You can remove default_app_config.`

This change fixes this warning.