### PR TITLE
perf: Skip syncing db comments for apps already synced in TransactionTestCase

### DIFF
--- a/django_db_comments/db_comments.py
+++ b/django_db_comments/db_comments.py
@@ -23,6 +23,11 @@ POSTGRES_COMMENT_SQL = sql.SQL("COMMENT ON COLUMN {}.{} IS %s")
 
 POSTGRES_COMMENT_ON_TABLE_SQL = sql.SQL("COMMENT ON TABLE {} IS %s")
 
+# For TransactionTestCase tests, the post_migrate signal is fired as part of a flush
+# operation after each test. We keep track of the apps we've synced the comments for
+# in order to avoid syncing db comments after each test.
+PROCESSED_APPS = set()
+
 
 def get_comments_for_model(model):
     column_comments = {}
@@ -91,6 +96,9 @@ def copy_help_texts_to_database(
     """
     Create content types for models in the given app.
     """
+    if app_config in PROCESSED_APPS:
+        return
+    PROCESSED_APPS.add(app_config)
     if not _check_app_config(app_config, using):
         return
 

--- a/tests/test_db_comments.py
+++ b/tests/test_db_comments.py
@@ -13,7 +13,7 @@ from psycopg2 import sql
 
 from django.apps import apps
 from django.db import models, DEFAULT_DB_ALIAS
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 try:
     from django.utils.translation import ugettext_lazy as _
@@ -116,6 +116,8 @@ class TestDjangoDbComments(TestCase):
             },
         )
 
+class TestDbcommentsSignal(TransactionTestCase):
+    available_apps = ["django_db_comments", "tests"]
     def test_post_migrate_signal(self):
         app_config = apps.get_app_config("tests")
         with patch(
@@ -129,12 +131,20 @@ class TestDjangoDbComments(TestCase):
                     "django_db_comments.db_comments.add_table_comments_to_database",
                     return_value=True,
                 ) as mock_table_comments:
-                    copy_help_texts_to_database(app_config)
-                    mock_table_comments.assert_called_once_with(
-                        {"tests_examplemodel": "This Is An Example For Table Comment"},
-                        "default",
-                    )
-                    mock_column_comments.assert_called_once_with(
-                        {"tests_examplemodel": {"created_at": "model creation time"}},
-                        "default",
-                    )
+                    with patch("django_db_comments.db_comments.PROCESSED_APPS", set()):
+                        copy_help_texts_to_database(app_config)
+                        mock_table_comments.assert_called_once_with(
+                            {"tests_examplemodel": "This Is An Example For Table Comment"},
+                            "default",
+                        )
+                        mock_column_comments.assert_called_once_with(
+                            {"tests_examplemodel": {"created_at": "model creation time"}},
+                            "default",
+                        )
+                        # make sure they're not called multiple times
+                        mock_table_comments.reset_mock()
+                        mock_column_comments.reset_mock()
+
+                        copy_help_texts_to_database(app_config)
+                        mock_table_comments.assert_not_called()
+                        mock_column_comments.assert_not_called()


### PR DESCRIPTION
## Summary
- Improves performance by avoiding redundant database comment syncing during TransactionTestCase tests
- Adds tracking mechanism to prevent multiple comment sync operations for the same app
- Reduces test execution time by eliminating unnecessary database operations

## Problem
Django's `TransactionTestCase` calls `flush` after each test, which emits the `post_migrate` signal and triggers database comment syncing. This becomes expensive proportionally to the number of models, causing slower test execution.

As noted in [Django docs](https://docs.djangoproject.com/en/5.1/topics/testing/advanced/#advanced-features-of-transactiontestcase):
> After each test, Django calls flush to reset the database state. This empties all tables and emits the post_migrate signal, which recreates one content type and four permissions for each model. This operation gets expensive proportionally to the number of models.

## Changes
- Add `PROCESSED_APPS` global set to track apps that have already been processed
- Check if app is already processed before syncing comments in `copy_help_texts_to_database()`
- Move `test_post_migrate_signal` to new `TestDbcommentsSignal(TransactionTestCase)` class with proper test isolation
- Add comprehensive test coverage to verify apps are not processed multiple times

## Performance Impact
This change significantly improves test execution speed by preventing redundant database comment operations during test runs.

## Test plan
- [x] Existing functionality remains unchanged
- [x] New test verifies single processing per app
- [x] TransactionTestCase properly isolated with `available_apps`
- [x] All tests continue to pass

Based on commit `693501d` addressing SC-102662.

🤖 Generated with [Claude Code](https://claude.ai/code)